### PR TITLE
Switch Garmin auth to multi-strategy SSO with DI token refresh

### DIFF
--- a/crates/garmin-cli/src/cli/commands/auth.rs
+++ b/crates/garmin-cli/src/cli/commands/auth.rs
@@ -125,7 +125,7 @@ pub async fn refresh_token(store: &CredentialStore) -> Result<(OAuth1Token, OAut
 
     println!("Refreshing access token...");
     let sso_client = SsoClient::new()?;
-    let new_oauth2 = sso_client.refresh_oauth2(&oauth1).await?;
+    let new_oauth2 = sso_client.refresh_oauth2(&oauth1, &oauth2).await?;
 
     store.save_oauth2(&new_oauth2)?;
 

--- a/crates/garmin-cli/src/client/api.rs
+++ b/crates/garmin-cli/src/client/api.rs
@@ -12,8 +12,10 @@ use std::path::Path;
 use crate::client::tokens::OAuth2Token;
 use crate::error::{GarminError, Result};
 
-/// User agent for Connect API requests
-const API_USER_AGENT: &str = "GCM-iOS-5.7.2.1";
+/// Native mobile headers for Connect API requests.
+const API_USER_AGENT: &str = "GCM-Android-5.23";
+const X_GARMIN_USER_AGENT: &str =
+    "com.garmin.android.apps.connectmobile/5.23; ; Google/sdk_gphone64_arm64/google; Android/33; Dalvik/2.1.0";
 
 /// Garmin Connect API client
 #[derive(Clone)]
@@ -59,6 +61,13 @@ impl GarminClient {
             AUTHORIZATION,
             HeaderValue::from_str(&token.authorization_header()).unwrap(),
         );
+        headers.insert("X-Garmin-User-Agent", HeaderValue::from_static(X_GARMIN_USER_AGENT));
+        headers.insert("X-Garmin-Paired-App-Version", HeaderValue::from_static("10861"));
+        headers.insert("X-Garmin-Client-Platform", HeaderValue::from_static("Android"));
+        headers.insert("X-App-Ver", HeaderValue::from_static("10861"));
+        headers.insert("X-Lang", HeaderValue::from_static("en"));
+        headers.insert("X-GCExperience", HeaderValue::from_static("GC5"));
+        headers.insert("Accept-Language", HeaderValue::from_static("en-US,en;q=0.9"));
         headers
     }
 

--- a/crates/garmin-cli/src/client/sso.rs
+++ b/crates/garmin-cli/src/client/sso.rs
@@ -1,54 +1,69 @@
 //! Garmin SSO Authentication
 //!
-//! Implements the Garmin Connect SSO login flow using the mobile JSON API.
-//!
-//! ## Background
-//!
-//! The previous implementation scraped `<title>` tags from Garmin's SSO HTML
-//! page to determine login status (matching `garth < 0.8.0`). Garmin changed
-//! their SSO page structure, breaking this approach.
-//!
-//! This implementation ports the approach from `garth 0.8.0`, which switched
-//! to Garmin's mobile JSON API endpoints:
-//! - `GET  /mobile/sso/en/sign-in` — establish session cookies
-//! - `POST /mobile/api/login` — submit credentials, receive ticket or MFA challenge
-//! - `POST /mobile/api/mfa/verifyCode` — verify MFA code if required
-//!
-//! Reference: <https://github.com/matin/garth/blob/main/garth/sso.py>
+//! Garmin's login behavior changed in March 2026. Browser logins may still work
+//! while programmatic mobile auth endpoints reject non-browser clients. This
+//! implementation now tries multiple login strategies and prefers native DI OAuth
+//! bearer tokens when a service ticket is obtained.
 
 use crate::client::oauth1::{parse_oauth_response, OAuth1Signer, OAuthConsumer, OAuthToken};
 use crate::client::tokens::{OAuth1Token, OAuth2Token};
 use crate::error::{GarminError, Result};
+use base64::{
+    engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
+    Engine as _,
+};
+use rand::Rng;
+use regex::Regex;
 use reqwest::cookie::Jar;
 use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE, USER_AGENT};
-use reqwest::Client;
+use reqwest::{Client, Response, StatusCode};
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-/// Default Garmin domain
+/// Default Garmin domain.
 const DEFAULT_DOMAIN: &str = "garmin.com";
 
-/// Client ID for mobile API login
-const CLIENT_ID: &str = "GCM_ANDROID_DARK";
+/// Mobile iOS auth flow constants.
+const IOS_CLIENT_ID: &str = "GCM_IOS_DARK";
+const IOS_SERVICE_URL: &str = "https://mobile.integration.garmin.com/gcm/ios";
+const IOS_LOGIN_USER_AGENT: &str = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148";
 
-/// User agent mimicking the Garmin mobile app (for OAuth endpoints)
-const MOBILE_USER_AGENT: &str = "com.garmin.android.apps.connectmobile";
+/// Portal/browser flow constants.
+const PORTAL_CLIENT_ID: &str = "GarminConnect";
+const PORTAL_SERVICE_URL: &str = "https://connect.garmin.com/app";
+const PORTAL_LOGIN_USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
 
-/// Browser-like user agent for SSO pages (avoids Cloudflare challenges)
-const SSO_USER_AGENT: &str = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148";
+/// Native DI token exchange constants.
+const DI_TOKEN_URL: &str = "https://diauth.garmin.com/di-oauth2-service/oauth/token";
+const DI_GRANT_TYPE: &str =
+    "https://connectapi.garmin.com/di-oauth2-service/oauth/grant/service_ticket";
+const DI_API_USER_AGENT: &str = "GCM-Android-5.23";
+const DI_X_GARMIN_USER_AGENT: &str =
+    "com.garmin.android.apps.connectmobile/5.23; ; Google/sdk_gphone64_arm64/google; Android/33; Dalvik/2.1.0";
+const DI_CLIENT_IDS: &[&str] = &[
+    "GARMIN_CONNECT_MOBILE_ANDROID_DI_2025Q2",
+    "GARMIN_CONNECT_MOBILE_ANDROID_DI_2024Q4",
+    "GARMIN_CONNECT_MOBILE_ANDROID_DI",
+    "GARMIN_CONNECT_MOBILE_IOS_DI",
+];
 
-/// URL to fetch OAuth consumer credentials
+/// Legacy OAuth1 exchange fallback.
+const LEGACY_MOBILE_USER_AGENT: &str = "com.garmin.android.apps.connectmobile";
 const OAUTH_CONSUMER_URL: &str = "https://thegarth.s3.amazonaws.com/oauth_consumer.json";
 
-/// OAuth consumer credentials fetched from Garth's S3
+/// Anti-WAF delays for browser-like flows.
+const PORTAL_DELAY_MIN_S: f64 = 10.0;
+const PORTAL_DELAY_MAX_S: f64 = 20.0;
+const WIDGET_DELAY_MIN_S: f64 = 3.0;
+const WIDGET_DELAY_MAX_S: f64 = 8.0;
+
 #[derive(Debug, Deserialize)]
 struct OAuthConsumerResponse {
     consumer_key: String,
     consumer_secret: String,
 }
 
-/// SSO login request body
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct LoginRequest<'a> {
@@ -58,7 +73,6 @@ struct LoginRequest<'a> {
     captcha_token: &'a str,
 }
 
-/// SSO MFA verification request body
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct MfaVerifyRequest<'a> {
@@ -69,7 +83,6 @@ struct MfaVerifyRequest<'a> {
     mfa_setup: bool,
 }
 
-/// SSO response status
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct SsoResponseStatus {
@@ -79,7 +92,6 @@ struct SsoResponseStatus {
     message: String,
 }
 
-/// SSO login/MFA response
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct SsoResponse {
@@ -89,9 +101,10 @@ struct SsoResponse {
     service_ticket_id: Option<String>,
     #[serde(default)]
     customer_mfa_info: Option<MfaInfo>,
+    #[serde(default)]
+    error: Option<SsoErrorResponse>,
 }
 
-/// MFA information from login response
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct MfaInfo {
@@ -99,28 +112,117 @@ struct MfaInfo {
     mfa_last_method_used: Option<String>,
 }
 
-/// SSO Client for Garmin authentication
+#[derive(Debug, Deserialize)]
+struct SsoErrorResponse {
+    #[serde(rename = "status-code")]
+    status_code: String,
+    #[serde(default)]
+    message: String,
+    #[serde(rename = "request-id", default)]
+    request_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DiTokenResponse {
+    access_token: String,
+    #[serde(default)]
+    refresh_token: String,
+    #[serde(default)]
+    token_type: Option<String>,
+    #[serde(default)]
+    scope: Option<String>,
+    #[serde(default)]
+    jti: Option<String>,
+    #[serde(default)]
+    expires_in: Option<i64>,
+    #[serde(default)]
+    refresh_token_expires_in: Option<i64>,
+}
+
+#[derive(Clone, Copy)]
+enum JsonLoginFlow {
+    Mobile,
+    Portal,
+}
+
+struct LoginStrategySuccess {
+    ticket: String,
+    service_url: String,
+}
+
+/// SSO Client for Garmin authentication.
 pub struct SsoClient {
     client: Client,
 }
 
 impl SsoClient {
-    /// Create a new SSO client
+    /// Create a new SSO client.
     pub fn new() -> Result<Self> {
-        let cookie_jar = Arc::new(Jar::default());
         let client = Client::builder()
-            .cookie_provider(cookie_jar)
-            .timeout(std::time::Duration::from_secs(30))
+            .timeout(Duration::from_secs(30))
             .build()
             .map_err(GarminError::Http)?;
 
         Ok(Self { client })
     }
 
-    /// Build SSO page headers (browser-like to establish session cookies)
-    fn sso_page_headers() -> HeaderMap {
+    fn new_session_client() -> Result<Client> {
+        let cookie_jar = Arc::new(Jar::default());
+        Client::builder()
+            .cookie_provider(cookie_jar)
+            .timeout(Duration::from_secs(30))
+            .build()
+            .map_err(GarminError::Http)
+    }
+
+    fn json_login_params(flow: JsonLoginFlow) -> [(&'static str, &'static str); 3] {
+        match flow {
+            JsonLoginFlow::Mobile => [
+                ("clientId", IOS_CLIENT_ID),
+                ("locale", "en-US"),
+                ("service", IOS_SERVICE_URL),
+            ],
+            JsonLoginFlow::Portal => [
+                ("clientId", PORTAL_CLIENT_ID),
+                ("locale", "en-US"),
+                ("service", PORTAL_SERVICE_URL),
+            ],
+        }
+    }
+
+    fn flow_service_url(flow: JsonLoginFlow) -> &'static str {
+        match flow {
+            JsonLoginFlow::Mobile => IOS_SERVICE_URL,
+            JsonLoginFlow::Portal => PORTAL_SERVICE_URL,
+        }
+    }
+
+    fn flow_path(flow: JsonLoginFlow) -> &'static str {
+        match flow {
+            JsonLoginFlow::Mobile => "mobile",
+            JsonLoginFlow::Portal => "portal",
+        }
+    }
+
+    fn mobile_headers() -> HeaderMap {
         let mut headers = HeaderMap::new();
-        headers.insert(USER_AGENT, HeaderValue::from_static(SSO_USER_AGENT));
+        headers.insert(USER_AGENT, HeaderValue::from_static(IOS_LOGIN_USER_AGENT));
+        headers.insert(
+            "Accept",
+            HeaderValue::from_static("application/json, text/plain, */*"),
+        );
+        headers.insert(
+            "Accept-Language",
+            HeaderValue::from_static("en-US,en;q=0.9"),
+        );
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        headers.insert("Origin", HeaderValue::from_static("https://sso.garmin.com"));
+        headers
+    }
+
+    fn portal_page_headers() -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(USER_AGENT, HeaderValue::from_static(PORTAL_LOGIN_USER_AGENT));
         headers.insert(
             "Accept",
             HeaderValue::from_static(
@@ -131,15 +233,12 @@ impl SsoClient {
             "Accept-Language",
             HeaderValue::from_static("en-US,en;q=0.9"),
         );
-        headers.insert("Sec-Fetch-Mode", HeaderValue::from_static("navigate"));
-        headers.insert("Sec-Fetch-Dest", HeaderValue::from_static("document"));
         headers
     }
 
-    /// Build mobile JSON API headers for login/MFA endpoints
-    fn sso_api_headers() -> HeaderMap {
+    fn portal_api_headers(referer: &str) -> Result<HeaderMap> {
         let mut headers = HeaderMap::new();
-        headers.insert(USER_AGENT, HeaderValue::from_static(MOBILE_USER_AGENT));
+        headers.insert(USER_AGENT, HeaderValue::from_static(PORTAL_LOGIN_USER_AGENT));
         headers.insert(
             "Accept",
             HeaderValue::from_static("application/json, text/plain, */*"),
@@ -152,197 +251,693 @@ impl SsoClient {
         headers.insert("Origin", HeaderValue::from_static("https://sso.garmin.com"));
         headers.insert(
             "Referer",
-            HeaderValue::from_static("https://sso.garmin.com/mobile/sso/en/sign-in"),
+            HeaderValue::from_str(referer)
+                .map_err(|e| GarminError::invalid_response(format!("Invalid referer: {}", e)))?,
+        );
+        Ok(headers)
+    }
+
+    fn native_headers() -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(USER_AGENT, HeaderValue::from_static(DI_API_USER_AGENT));
+        headers.insert(
+            "X-Garmin-User-Agent",
+            HeaderValue::from_static(DI_X_GARMIN_USER_AGENT),
+        );
+        headers.insert(
+            "X-Garmin-Paired-App-Version",
+            HeaderValue::from_static("10861"),
+        );
+        headers.insert(
+            "X-Garmin-Client-Platform",
+            HeaderValue::from_static("Android"),
+        );
+        headers.insert("X-App-Ver", HeaderValue::from_static("10861"));
+        headers.insert("X-Lang", HeaderValue::from_static("en"));
+        headers.insert("X-GCExperience", HeaderValue::from_static("GC5"));
+        headers.insert(
+            "Accept-Language",
+            HeaderValue::from_static("en-US,en;q=0.9"),
         );
         headers
     }
 
-    /// Perform full login flow using mobile JSON API
-    pub async fn login(
+    /// Perform login using multiple SSO flows.
+    pub async fn login<F>(
         &mut self,
         email: &str,
         password: &str,
-        mfa_callback: Option<impl FnOnce() -> String>,
-    ) -> Result<(OAuth1Token, OAuth2Token)> {
-        let service_url = format!("https://mobile.integration.{}/gcm/android", DEFAULT_DOMAIN);
-        let login_params = [
-            ("clientId", CLIENT_ID),
-            ("locale", "en-US"),
-            ("service", service_url.as_str()),
-        ];
+        mut mfa_callback: Option<F>,
+    ) -> Result<(OAuth1Token, OAuth2Token)>
+    where
+        F: FnMut() -> String,
+    {
+        let mut failures = Vec::new();
 
-        // Step 1: Set cookies by visiting the sign-in page
-        let sign_in_url = format!("https://sso.{}/mobile/sso/en/sign-in", DEFAULT_DOMAIN);
-        let mut headers = Self::sso_page_headers();
-        headers.insert("Sec-Fetch-Site", HeaderValue::from_static("none"));
-
-        let _ = self
-            .client
-            .get(&sign_in_url)
-            .query(&[("clientId", CLIENT_ID)])
-            .headers(headers)
-            .send()
+        match self
+            .login_mobile_ios(email, password, mfa_callback.as_mut())
             .await
-            .map_err(GarminError::Http)?
-            .text()
-            .await;
+        {
+            Ok(success) => return self.complete_login(&success.ticket, &success.service_url).await,
+            Err(err @ GarminError::Authentication(_)) | Err(err @ GarminError::MfaRequired) => {
+                return Err(err);
+            }
+            Err(err) => failures.push(format!("mobile: {}", Self::summarize_strategy_error(&err))),
+        }
 
-        // Step 2: Submit login via JSON API
-        let login_url = format!("https://sso.{}/mobile/api/login", DEFAULT_DOMAIN);
+        match self.login_widget(email, password, mfa_callback.as_mut()).await {
+            Ok(success) => return self.complete_login(&success.ticket, &success.service_url).await,
+            Err(err @ GarminError::Authentication(_)) | Err(err @ GarminError::MfaRequired) => {
+                return Err(err);
+            }
+            Err(err) => failures.push(format!("widget: {}", Self::summarize_strategy_error(&err))),
+        }
+
+        match self
+            .login_portal(email, password, mfa_callback.as_mut())
+            .await
+        {
+            Ok(success) => return self.complete_login(&success.ticket, &success.service_url).await,
+            Err(err @ GarminError::Authentication(_)) | Err(err @ GarminError::MfaRequired) => {
+                return Err(err);
+            }
+            Err(err) => failures.push(format!("portal: {}", Self::summarize_strategy_error(&err))),
+        }
+
+        Err(GarminError::auth(format!(
+            "Garmin rejected every non-browser login strategy. Browser login can still work while the CLI fails because Garmin/Cloudflare now fingerprints the client, not just your credentials. Strategy results: {}",
+            failures.join("; ")
+        )))
+    }
+
+    async fn login_mobile_ios<F>(
+        &self,
+        email: &str,
+        password: &str,
+        mfa_callback: Option<&mut F>,
+    ) -> Result<LoginStrategySuccess>
+    where
+        F: FnMut() -> String,
+    {
+        let session = Self::new_session_client()?;
         let login_body = LoginRequest {
             username: email,
             password,
-            remember_me: false,
+            remember_me: true,
             captcha_token: "",
         };
+        let headers = Self::mobile_headers();
 
-        let response = self
-            .client
-            .post(&login_url)
-            .query(&login_params)
-            .headers(Self::sso_api_headers())
+        let response = session
+            .post(format!("https://sso.{}/mobile/api/login", DEFAULT_DOMAIN))
+            .query(&Self::json_login_params(JsonLoginFlow::Mobile))
+            .headers(headers.clone())
             .json(&login_body)
             .send()
             .await
             .map_err(GarminError::Http)?;
 
-        let status_code = response.status();
-        let body_text = response.text().await.unwrap_or_default();
+        self.handle_json_login_response(
+            &session,
+            response,
+            JsonLoginFlow::Mobile,
+            headers,
+            mfa_callback,
+        )
+        .await
+    }
 
-        if status_code.as_u16() == 429 {
-            return Err(GarminError::auth(format!(
-                "Rate limited by Garmin (429). Response body: {}",
-                &body_text[..body_text.len().min(400)]
+    async fn login_widget<F>(
+        &self,
+        email: &str,
+        password: &str,
+        mfa_callback: Option<&mut F>,
+    ) -> Result<LoginStrategySuccess>
+    where
+        F: FnMut() -> String,
+    {
+        let session = Self::new_session_client()?;
+        let sso_base = format!("https://sso.{}/sso", DEFAULT_DOMAIN);
+        let embed_url = format!("{}/embed", sso_base);
+        let embed_params = [
+            ("id", "gauth-widget"),
+            ("embedWidget", "true"),
+            ("gauthHost", sso_base.as_str()),
+        ];
+
+        let response = session
+            .get(&embed_url)
+            .query(&embed_params)
+            .headers(Self::portal_page_headers())
+            .send()
+            .await
+            .map_err(GarminError::Http)?;
+
+        if Self::is_rate_limited_response(&response, "") {
+            return Err(GarminError::RateLimited);
+        }
+        if !response.status().is_success() {
+            return Err(GarminError::Other(format!(
+                "widget embed returned {}",
+                response.status()
             )));
         }
-        if !status_code.is_success() && status_code.as_u16() != 200 {
-            return Err(GarminError::auth(format!(
-                "SSO HTTP {}. Response body: {}",
-                status_code,
-                &body_text[..body_text.len().min(400)]
+
+        let signin_params = [
+            ("id", "gauth-widget"),
+            ("embedWidget", "true"),
+            ("gauthHost", embed_url.as_str()),
+            ("service", embed_url.as_str()),
+            ("source", embed_url.as_str()),
+            ("redirectAfterAccountLoginUrl", embed_url.as_str()),
+            ("redirectAfterAccountCreationUrl", embed_url.as_str()),
+        ];
+
+        let signin_response = session
+            .get(format!("https://sso.{}/sso/signin", DEFAULT_DOMAIN))
+            .query(&signin_params)
+            .header("Referer", &embed_url)
+            .headers(Self::portal_page_headers())
+            .send()
+            .await
+            .map_err(GarminError::Http)?;
+
+        let signin_status = signin_response.status();
+        let signin_body = signin_response.text().await.unwrap_or_default();
+        if signin_status == StatusCode::TOO_MANY_REQUESTS || Self::body_is_429(&signin_body) {
+            return Err(GarminError::RateLimited);
+        }
+        if !signin_status.is_success() {
+            return Err(GarminError::Other(format!(
+                "widget signin returned {}",
+                signin_status
             )));
         }
 
-        let sso_resp: SsoResponse = serde_json::from_str(&body_text).map_err(|e| {
-            GarminError::invalid_response(format!(
-                "Failed to parse SSO response: {} | body: {}",
-                e,
-                &body_text[..body_text.len().min(200)]
+        let csrf = Self::extract_csrf(&signin_body)
+            .ok_or_else(|| GarminError::Other("widget login missing CSRF token".to_string()))?;
+
+        Self::delay_between(WIDGET_DELAY_MIN_S, WIDGET_DELAY_MAX_S).await;
+
+        let post_response = session
+            .post(format!("https://sso.{}/sso/signin", DEFAULT_DOMAIN))
+            .query(&signin_params)
+            .header("Referer", &embed_url)
+            .form(&[
+                ("username", email),
+                ("password", password),
+                ("embed", "true"),
+                ("_csrf", csrf.as_str()),
+            ])
+            .send()
+            .await
+            .map_err(GarminError::Http)?;
+
+        let post_url = post_response.url().to_string();
+        let post_status = post_response.status();
+        let post_body = post_response.text().await.unwrap_or_default();
+
+        if post_status == StatusCode::TOO_MANY_REQUESTS || Self::body_is_429(&post_body) {
+            return Err(GarminError::RateLimited);
+        }
+
+        let title = Self::extract_title(&post_body).unwrap_or_default();
+        let title_lower = title.to_lowercase();
+        if ["bad gateway", "service unavailable", "cloudflare", "502", "503"]
+            .iter()
+            .any(|hint| title_lower.contains(hint))
+        {
+            return Err(GarminError::Other(format!(
+                "widget login blocked by Garmin/Cloudflare ({})",
+                title
+            )));
+        }
+        if ["locked", "invalid", "incorrect", "account error"]
+            .iter()
+            .any(|hint| title_lower.contains(hint))
+        {
+            return Err(GarminError::auth(format!(
+                "Widget authentication failed: {}",
+                title
+            )));
+        }
+        if title.contains("MFA") {
+            let callback = mfa_callback.ok_or(GarminError::MfaRequired)?;
+            let mfa_code = callback();
+            return self
+                .submit_widget_mfa(
+                    &session,
+                    &mfa_code,
+                    &signin_params,
+                    &post_url,
+                    &post_body,
+                    &embed_url,
+                )
+                .await;
+        }
+        if title != "Success" {
+            return Err(GarminError::Other(format!(
+                "widget login unexpected title '{}'",
+                title
+            )));
+        }
+
+        let ticket = Self::extract_widget_ticket(&post_body).ok_or_else(|| {
+            GarminError::Other("widget login missing service ticket".to_string())
+        })?;
+
+        Ok(LoginStrategySuccess {
+            ticket,
+            service_url: embed_url,
+        })
+    }
+
+    async fn login_portal<F>(
+        &self,
+        email: &str,
+        password: &str,
+        mfa_callback: Option<&mut F>,
+    ) -> Result<LoginStrategySuccess>
+    where
+        F: FnMut() -> String,
+    {
+        let session = Self::new_session_client()?;
+        let signin_url = format!("https://sso.{}/portal/sso/en-US/sign-in", DEFAULT_DOMAIN);
+        let get_response = session
+            .get(&signin_url)
+            .query(&[
+                ("clientId", PORTAL_CLIENT_ID),
+                ("service", PORTAL_SERVICE_URL),
+            ])
+            .headers(Self::portal_page_headers())
+            .send()
+            .await
+            .map_err(GarminError::Http)?;
+
+        if Self::is_rate_limited_response(&get_response, "") {
+            return Err(GarminError::RateLimited);
+        }
+        if !get_response.status().is_success() {
+            return Err(GarminError::Other(format!(
+                "portal signin returned {}",
+                get_response.status()
+            )));
+        }
+
+        Self::delay_between(PORTAL_DELAY_MIN_S, PORTAL_DELAY_MAX_S).await;
+
+        let referer = format!(
+            "{}?clientId={}&service={}",
+            signin_url, PORTAL_CLIENT_ID, PORTAL_SERVICE_URL
+        );
+        let headers = Self::portal_api_headers(&referer)?;
+        let login_body = LoginRequest {
+            username: email,
+            password,
+            remember_me: true,
+            captcha_token: "",
+        };
+
+        let response = session
+            .post(format!("https://sso.{}/portal/api/login", DEFAULT_DOMAIN))
+            .query(&Self::json_login_params(JsonLoginFlow::Portal))
+            .headers(headers.clone())
+            .json(&login_body)
+            .send()
+            .await
+            .map_err(GarminError::Http)?;
+
+        self.handle_json_login_response(
+            &session,
+            response,
+            JsonLoginFlow::Portal,
+            headers,
+            mfa_callback,
+        )
+        .await
+    }
+
+    async fn handle_json_login_response<F>(
+        &self,
+        session: &Client,
+        response: Response,
+        flow: JsonLoginFlow,
+        headers: HeaderMap,
+        mfa_callback: Option<&mut F>,
+    ) -> Result<LoginStrategySuccess>
+    where
+        F: FnMut() -> String,
+    {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+
+        if status == StatusCode::TOO_MANY_REQUESTS || Self::body_is_429(&body) {
+            return Err(GarminError::RateLimited);
+        }
+
+        if !status.is_success() {
+            return Err(GarminError::Other(format!(
+                "{} login HTTP {}",
+                Self::flow_path(flow),
+                status
+            )));
+        }
+
+        let sso_resp: SsoResponse = serde_json::from_str(&body).map_err(|e| {
+            GarminError::Other(format!(
+                "{} login returned non-JSON or unexpected JSON: {}",
+                Self::flow_path(flow),
+                e
             ))
         })?;
 
         let resp_type = sso_resp
             .response_status
             .as_ref()
-            .map(|s| s.response_type.as_str())
+            .map(|status| status.response_type.as_str())
             .unwrap_or("UNKNOWN");
 
-        let ticket = match resp_type {
-            "SUCCESSFUL" => sso_resp
-                .service_ticket_id
-                .ok_or_else(|| GarminError::invalid_response("Missing serviceTicketId"))?,
-
+        match resp_type {
+            "SUCCESSFUL" => Ok(LoginStrategySuccess {
+                ticket: sso_resp
+                    .service_ticket_id
+                    .ok_or_else(|| GarminError::invalid_response("Missing serviceTicketId"))?,
+                service_url: Self::flow_service_url(flow).to_string(),
+            }),
             "MFA_REQUIRED" => {
+                let callback = mfa_callback.ok_or(GarminError::MfaRequired)?;
                 let mfa_method = sso_resp
                     .customer_mfa_info
                     .and_then(|info| info.mfa_last_method_used)
                     .unwrap_or_else(|| "email".to_string());
-
-                let mfa_code = mfa_callback.ok_or_else(|| GarminError::MfaRequired)?();
-
-                self.submit_mfa(&mfa_code, &mfa_method, &login_params)
-                    .await?
+                let mfa_code = callback();
+                self.submit_json_mfa(session, flow, &mfa_code, &mfa_method, headers)
+                    .await
             }
-
-            _ => {
-                let message = sso_resp
-                    .response_status
-                    .map(|s| {
-                        if s.message.is_empty() {
-                            s.response_type
-                        } else {
-                            format!("{}: {}", s.response_type, s.message)
-                        }
-                    })
-                    .unwrap_or_else(|| "Unknown error".to_string());
-                return Err(GarminError::auth(format!("SSO error: {}", message)));
+            "INVALID_USERNAME_PASSWORD" => {
+                Err(GarminError::auth("Invalid username or password"))
             }
-        };
-
-        // Step 3: Complete login (set Cloudflare LB cookie, get OAuth tokens)
-        self.complete_login(&ticket).await
+            _ => Err(GarminError::Other(format!(
+                "{} login failed: {}",
+                Self::flow_path(flow),
+                Self::describe_sso_response(&sso_resp, &body)
+            ))),
+        }
     }
 
-    /// Submit MFA verification code via JSON API
-    async fn submit_mfa(
+    async fn submit_json_mfa(
         &self,
+        session: &Client,
+        flow: JsonLoginFlow,
         mfa_code: &str,
         mfa_method: &str,
-        login_params: &[(&str, &str)],
-    ) -> Result<String> {
-        let mfa_url = format!("https://sso.{}/mobile/api/mfa/verifyCode", DEFAULT_DOMAIN);
-        let mfa_body = MfaVerifyRequest {
+        headers: HeaderMap,
+    ) -> Result<LoginStrategySuccess> {
+        let body = MfaVerifyRequest {
             mfa_method,
             mfa_verification_code: mfa_code,
-            remember_my_browser: false,
+            remember_my_browser: true,
             reconsent_list: vec![],
             mfa_setup: false,
         };
 
-        let response = self
-            .client
-            .post(&mfa_url)
-            .query(login_params)
-            .headers(Self::sso_api_headers())
-            .json(&mfa_body)
+        let primary = flow;
+        let secondary = match flow {
+            JsonLoginFlow::Mobile => JsonLoginFlow::Portal,
+            JsonLoginFlow::Portal => JsonLoginFlow::Mobile,
+        };
+
+        for candidate in [primary, secondary] {
+            let response = session
+                .post(format!(
+                    "https://sso.{}/{}/api/mfa/verifyCode",
+                    DEFAULT_DOMAIN,
+                    Self::flow_path(candidate)
+                ))
+                .query(&Self::json_login_params(candidate))
+                .headers(headers.clone())
+                .json(&body)
+                .send()
+                .await
+                .map_err(GarminError::Http)?;
+
+            let status = response.status();
+            let response_body = response.text().await.unwrap_or_default();
+            if status == StatusCode::TOO_MANY_REQUESTS || Self::body_is_429(&response_body) {
+                continue;
+            }
+            if !status.is_success() {
+                continue;
+            }
+
+            let sso_resp: SsoResponse = match serde_json::from_str(&response_body) {
+                Ok(parsed) => parsed,
+                Err(_) => continue,
+            };
+            let resp_type = sso_resp
+                .response_status
+                .as_ref()
+                .map(|status| status.response_type.as_str())
+                .unwrap_or("UNKNOWN");
+
+            if resp_type == "SUCCESSFUL" {
+                return Ok(LoginStrategySuccess {
+                    ticket: sso_resp.service_ticket_id.ok_or_else(|| {
+                        GarminError::invalid_response("Missing serviceTicketId after MFA")
+                    })?,
+                    service_url: Self::flow_service_url(flow).to_string(),
+                });
+            }
+        }
+
+        Err(GarminError::auth(
+            "MFA verification was blocked by Garmin/Cloudflare. Browser login can still work while non-browser auth fails.",
+        ))
+    }
+
+    async fn submit_widget_mfa(
+        &self,
+        session: &Client,
+        mfa_code: &str,
+        signin_params: &[(&str, &str)],
+        referer: &str,
+        widget_body: &str,
+        embed_url: &str,
+    ) -> Result<LoginStrategySuccess> {
+        let csrf = Self::extract_csrf(widget_body)
+            .ok_or_else(|| GarminError::auth("Widget MFA missing CSRF token"))?;
+
+        let response = session
+            .post(format!(
+                "https://sso.{}/sso/verifyMFA/loginEnterMfaCode",
+                DEFAULT_DOMAIN
+            ))
+            .query(signin_params)
+            .header("Referer", referer)
+            .form(&[
+                ("mfa-code", mfa_code),
+                ("embed", "true"),
+                ("_csrf", csrf.as_str()),
+                ("fromPage", "setupEnterMfaCode"),
+            ])
             .send()
             .await
             .map_err(GarminError::Http)?;
 
-        let sso_resp: SsoResponse = response.json().await.map_err(|e| {
-            GarminError::invalid_response(format!("Failed to parse MFA response: {}", e))
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        if status == StatusCode::TOO_MANY_REQUESTS || Self::body_is_429(&body) {
+            return Err(GarminError::auth(
+                "Widget MFA verification was blocked by Garmin/Cloudflare.",
+            ));
+        }
+
+        let title = Self::extract_title(&body).unwrap_or_default();
+        if title != "Success" {
+            return Err(GarminError::auth(format!("Widget MFA failed: {}", title)));
+        }
+
+        let ticket = Self::extract_widget_ticket(&body)
+            .ok_or_else(|| GarminError::auth("Widget MFA missing service ticket"))?;
+
+        Ok(LoginStrategySuccess {
+            ticket,
+            service_url: embed_url.to_string(),
+        })
+    }
+
+    async fn complete_login(
+        &self,
+        ticket: &str,
+        service_url: &str,
+    ) -> Result<(OAuth1Token, OAuth2Token)> {
+        match self.exchange_service_ticket_for_di(ticket, service_url).await {
+            Ok(oauth2) => Ok((OAuth1Token::new(String::new(), String::new()), oauth2)),
+            Err(_) => self.complete_login_legacy(ticket).await,
+        }
+    }
+
+    async fn exchange_service_ticket_for_di(
+        &self,
+        ticket: &str,
+        service_url: &str,
+    ) -> Result<OAuth2Token> {
+        let mut saw_rate_limit = false;
+        let mut last_error = String::new();
+
+        for client_id in DI_CLIENT_IDS {
+            let auth_header = format!("Basic {}", STANDARD.encode(format!("{}:", client_id)));
+            let response = self
+                .client
+                .post(DI_TOKEN_URL)
+                .headers(Self::native_headers())
+                .header("Authorization", auth_header)
+                .header("Accept", "application/json,text/html;q=0.9,*/*;q=0.8")
+                .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .header("Cache-Control", "no-cache")
+                .form(&[
+                    ("client_id", *client_id),
+                    ("service_ticket", ticket),
+                    ("grant_type", DI_GRANT_TYPE),
+                    ("service_url", service_url),
+                ])
+                .send()
+                .await
+                .map_err(GarminError::Http)?;
+
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            if status == StatusCode::TOO_MANY_REQUESTS || Self::body_is_429(&body) {
+                saw_rate_limit = true;
+                continue;
+            }
+            if !status.is_success() {
+                last_error = format!("{} returned HTTP {}", client_id, status);
+                continue;
+            }
+
+            let token_response: DiTokenResponse = match serde_json::from_str(&body) {
+                Ok(parsed) => parsed,
+                Err(err) => {
+                    last_error = format!("{} returned invalid JSON: {}", client_id, err);
+                    continue;
+                }
+            };
+
+            let now = Self::now_unix();
+            let expires_in = token_response.expires_in.unwrap_or(3600);
+            let refresh_token_expires_in = token_response.refresh_token_expires_in.unwrap_or(0);
+            let parsed_client_id = Self::extract_client_id_from_jwt(&token_response.access_token);
+
+            return Ok(OAuth2Token {
+                scope: token_response.scope.unwrap_or_default(),
+                jti: token_response.jti.unwrap_or_default(),
+                token_type: token_response
+                    .token_type
+                    .unwrap_or_else(|| "Bearer".to_string()),
+                access_token: token_response.access_token,
+                refresh_token: token_response.refresh_token,
+                expires_in,
+                expires_at: now + expires_in,
+                refresh_token_expires_in,
+                refresh_token_expires_at: if refresh_token_expires_in > 0 {
+                    now + refresh_token_expires_in
+                } else {
+                    0
+                },
+                client_id: Some(parsed_client_id.unwrap_or_else(|| (*client_id).to_string())),
+            });
+        }
+
+        if saw_rate_limit {
+            return Err(GarminError::RateLimited);
+        }
+
+        Err(GarminError::Other(format!(
+            "DI token exchange failed: {}",
+            last_error
+        )))
+    }
+
+    async fn refresh_di_oauth2(&self, oauth2: &OAuth2Token) -> Result<OAuth2Token> {
+        let client_id = oauth2.client_id.as_deref().ok_or_else(|| {
+            GarminError::auth("Stored session is missing DI client metadata. Log in again.")
         })?;
+        if oauth2.refresh_token.is_empty() {
+            return Err(GarminError::auth(
+                "Stored session is missing a refresh token. Log in again.",
+            ));
+        }
 
-        let resp_type = sso_resp
-            .response_status
-            .as_ref()
-            .map(|s| s.response_type.as_str())
-            .unwrap_or("UNKNOWN");
+        let auth_header = format!("Basic {}", STANDARD.encode(format!("{}:", client_id)));
+        let response = self
+            .client
+            .post(DI_TOKEN_URL)
+            .headers(Self::native_headers())
+            .header("Authorization", auth_header)
+            .header("Accept", "application/json")
+            .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
+            .header("Cache-Control", "no-cache")
+            .form(&[
+                ("grant_type", "refresh_token"),
+                ("client_id", client_id),
+                ("refresh_token", oauth2.refresh_token.as_str()),
+            ])
+            .send()
+            .await
+            .map_err(GarminError::Http)?;
 
-        if resp_type != "SUCCESSFUL" {
-            let message = sso_resp
-                .response_status
-                .map(|s| s.message)
-                .unwrap_or_default();
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        if status == StatusCode::TOO_MANY_REQUESTS || Self::body_is_429(&body) {
+            return Err(GarminError::RateLimited);
+        }
+        if !status.is_success() {
             return Err(GarminError::auth(format!(
-                "MFA verification failed: {}",
-                message
+                "Failed to refresh DI token: HTTP {}",
+                status
             )));
         }
 
-        sso_resp
-            .service_ticket_id
-            .ok_or_else(|| GarminError::invalid_response("Missing serviceTicketId after MFA"))
+        let token_response: DiTokenResponse = serde_json::from_str(&body).map_err(|e| {
+            GarminError::invalid_response(format!("Failed to parse refreshed DI token: {}", e))
+        })?;
+        let now = Self::now_unix();
+        let expires_in = token_response.expires_in.unwrap_or(3600);
+        let refresh_token_expires_in = token_response.refresh_token_expires_in.unwrap_or(0);
+        let access_token = token_response.access_token;
+        let parsed_client_id = Self::extract_client_id_from_jwt(&access_token);
+
+        Ok(OAuth2Token {
+            scope: token_response.scope.unwrap_or_default(),
+            jti: token_response.jti.unwrap_or_default(),
+            token_type: token_response
+                .token_type
+                .unwrap_or_else(|| "Bearer".to_string()),
+            access_token,
+            refresh_token: if token_response.refresh_token.is_empty() {
+                oauth2.refresh_token.clone()
+            } else {
+                token_response.refresh_token
+            },
+            expires_in,
+            expires_at: now + expires_in,
+            refresh_token_expires_in,
+            refresh_token_expires_at: if refresh_token_expires_in > 0 {
+                now + refresh_token_expires_in
+            } else {
+                oauth2.refresh_token_expires_at
+            },
+            client_id: Some(parsed_client_id.unwrap_or_else(|| client_id.to_string())),
+        })
     }
 
-    /// Complete login: set Cloudflare LB cookie and exchange for OAuth tokens
-    async fn complete_login(&self, ticket: &str) -> Result<(OAuth1Token, OAuth2Token)> {
-        // Best-effort: set Cloudflare LB cookie for backend pinning
-        let portal_url = format!("https://sso.{}/portal/sso/embed", DEFAULT_DOMAIN);
-        let mut headers = Self::sso_page_headers();
-        headers.insert("Sec-Fetch-Site", HeaderValue::from_static("same-origin"));
-        let _ = self.client.get(&portal_url).headers(headers).send().await;
-
-        // Exchange ticket for OAuth1 token
+    async fn complete_login_legacy(&self, ticket: &str) -> Result<(OAuth1Token, OAuth2Token)> {
         let oauth1 = self.get_oauth1_token(ticket).await?;
-
-        // Exchange OAuth1 for OAuth2 token
-        let oauth2 = self.exchange_oauth1_for_oauth2(&oauth1, true).await?;
-
+        let oauth2 = self.exchange_oauth1_for_oauth2_legacy(&oauth1, true).await?;
         Ok((oauth1, oauth2))
     }
 
-    /// Exchange ticket for OAuth1 token
     async fn get_oauth1_token(&self, ticket: &str) -> Result<OAuth1Token> {
         let consumer = self.fetch_oauth_consumer().await?;
 
@@ -360,15 +955,10 @@ impl SsoClient {
 
         let auth_header = signer.sign("GET", &url, &[]);
 
-        // Use a separate client without cookies (matches garth's OAuth1Session behavior)
-        let oauth_client = Client::builder()
-            .timeout(std::time::Duration::from_secs(30))
-            .build()
-            .map_err(GarminError::Http)?;
-
-        let response = oauth_client
+        let response = self
+            .client
             .get(&url)
-            .header(USER_AGENT, MOBILE_USER_AGENT)
+            .header(USER_AGENT, LEGACY_MOBILE_USER_AGENT)
             .header("Authorization", auth_header)
             .send()
             .await
@@ -396,7 +986,6 @@ impl SsoClient {
         let mfa_token = params.get("mfa_token").cloned();
 
         let mut token = OAuth1Token::new(oauth_token, oauth_token_secret);
-
         if let Some(mfa) = mfa_token {
             token = token.with_mfa(mfa, None);
         }
@@ -404,14 +993,12 @@ impl SsoClient {
         Ok(token)
     }
 
-    /// Exchange OAuth1 token for OAuth2 token
-    async fn exchange_oauth1_for_oauth2(
+    async fn exchange_oauth1_for_oauth2_legacy(
         &self,
         oauth1: &OAuth1Token,
         login: bool,
     ) -> Result<OAuth2Token> {
         let consumer = self.fetch_oauth_consumer().await?;
-
         let url = format!(
             "https://connectapi.{}/oauth-service/oauth/exchange/user/2.0",
             DEFAULT_DOMAIN
@@ -438,15 +1025,10 @@ impl SsoClient {
         }
 
         let auth_header = signer.sign("POST", &url, &form_params);
-
-        let oauth_client = Client::builder()
-            .timeout(std::time::Duration::from_secs(30))
-            .build()
-            .map_err(GarminError::Http)?;
-
-        let mut request = oauth_client
+        let mut request = self
+            .client
             .post(&url)
-            .header(USER_AGENT, MOBILE_USER_AGENT)
+            .header(USER_AGENT, LEGACY_MOBILE_USER_AGENT)
             .header("Authorization", auth_header)
             .header(CONTENT_TYPE, "application/x-www-form-urlencoded");
 
@@ -455,7 +1037,6 @@ impl SsoClient {
         }
 
         let response = request.send().await.map_err(GarminError::Http)?;
-
         let status = response.status();
         if !status.is_success() {
             return Err(GarminError::auth(format!(
@@ -468,17 +1049,14 @@ impl SsoClient {
             GarminError::invalid_response(format!("Failed to parse OAuth2 token: {}", e))
         })?;
 
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs() as i64;
+        let now = Self::now_unix();
         token.expires_at = now + token.expires_in;
         token.refresh_token_expires_at = now + token.refresh_token_expires_in;
+        token.client_id = None;
 
         Ok(token)
     }
 
-    /// Fetch OAuth consumer credentials from Garth's S3
     async fn fetch_oauth_consumer(&self) -> Result<OAuthConsumerResponse> {
         let response = self
             .client
@@ -492,21 +1070,127 @@ impl SsoClient {
         })
     }
 
-    /// Refresh OAuth2 token using OAuth1 token
-    pub async fn refresh_oauth2(&self, oauth1: &OAuth1Token) -> Result<OAuth2Token> {
-        self.exchange_oauth1_for_oauth2(oauth1, false).await
+    /// Refresh OAuth2 token. Prefer DI refresh, then fall back to the legacy
+    /// OAuth1 exchange for existing saved sessions.
+    pub async fn refresh_oauth2(
+        &self,
+        oauth1: &OAuth1Token,
+        oauth2: &OAuth2Token,
+    ) -> Result<OAuth2Token> {
+        if oauth2.client_id.is_some() && !oauth2.refresh_token.is_empty() {
+            return self.refresh_di_oauth2(oauth2).await;
+        }
+
+        if !oauth1.oauth_token.is_empty() && !oauth1.oauth_token_secret.is_empty() {
+            return self.exchange_oauth1_for_oauth2_legacy(oauth1, false).await;
+        }
+
+        Err(GarminError::auth(
+            "Stored session cannot be refreshed automatically. Please run 'garmin auth login' again.",
+        ))
+    }
+
+    fn summarize_strategy_error(error: &GarminError) -> String {
+        match error {
+            GarminError::RateLimited => {
+                "Garmin returned 429 or a rate-limit-style block".to_string()
+            }
+            GarminError::Other(message) => message.clone(),
+            _ => error.to_string(),
+        }
+    }
+
+    fn describe_sso_response(response: &SsoResponse, raw_body: &str) -> String {
+        if let Some(status) = &response.response_status {
+            if status.message.is_empty() {
+                return status.response_type.clone();
+            }
+            return format!("{}: {}", status.response_type, status.message);
+        }
+
+        if let Some(error) = &response.error {
+            return Self::format_sso_error(error);
+        }
+
+        Self::truncate(raw_body, 200)
+    }
+
+    fn format_sso_error(error: &SsoErrorResponse) -> String {
+        let mut details = format!("status {}", error.status_code);
+        if !error.message.is_empty() && error.message != "{}" {
+            details.push_str(&format!(": {}", error.message));
+        }
+        if let Some(request_id) = &error.request_id {
+            details.push_str(&format!(" (request-id {})", request_id));
+        }
+        details
+    }
+
+    fn is_rate_limited_response(response: &Response, body: &str) -> bool {
+        response.status() == StatusCode::TOO_MANY_REQUESTS || Self::body_is_429(body)
+    }
+
+    fn body_is_429(body: &str) -> bool {
+        serde_json::from_str::<SsoResponse>(body)
+            .ok()
+            .and_then(|resp| resp.error)
+            .map(|error| error.status_code == "429")
+            .unwrap_or(false)
+    }
+
+    fn extract_csrf(html: &str) -> Option<String> {
+        static REGEX: OnceLock<Regex> = OnceLock::new();
+        REGEX
+            .get_or_init(|| Regex::new(r#"name="_csrf"\s+value="([^"]+)""#).unwrap())
+            .captures(html)
+            .and_then(|captures| captures.get(1).map(|m| m.as_str().to_string()))
+    }
+
+    fn extract_title(html: &str) -> Option<String> {
+        static REGEX: OnceLock<Regex> = OnceLock::new();
+        REGEX
+            .get_or_init(|| Regex::new(r"(?is)<title>\s*(.*?)\s*</title>").unwrap())
+            .captures(html)
+            .and_then(|captures| captures.get(1).map(|m| m.as_str().trim().to_string()))
+    }
+
+    fn extract_widget_ticket(html: &str) -> Option<String> {
+        static REGEX: OnceLock<Regex> = OnceLock::new();
+        REGEX
+            .get_or_init(|| Regex::new(r#"embed\?ticket=([^"&]+)"#).unwrap())
+            .captures(html)
+            .and_then(|captures| captures.get(1).map(|m| m.as_str().to_string()))
+    }
+
+    fn extract_client_id_from_jwt(token: &str) -> Option<String> {
+        let payload = token.split('.').nth(1)?;
+        let decoded = URL_SAFE_NO_PAD.decode(payload.as_bytes()).ok()?;
+        let json: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
+        json.get("client_id")
+            .and_then(|value| value.as_str())
+            .map(|value| value.to_string())
+    }
+
+    async fn delay_between(min_seconds: f64, max_seconds: f64) {
+        let delay = rand::thread_rng().gen_range(min_seconds..=max_seconds);
+        tokio::time::sleep(Duration::from_secs_f64(delay)).await;
+    }
+
+    fn now_unix() -> i64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64
+    }
+
+    fn truncate(text: &str, max_len: usize) -> String {
+        text.chars().take(max_len).collect()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_sso_client_creation() {
-        let client = SsoClient::new();
-        assert!(client.is_ok());
-    }
 
     #[test]
     fn test_parse_successful_sso_response() {
@@ -537,22 +1221,27 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_failed_sso_response() {
-        let json = r#"{
-            "responseStatus": {"type": "FAIL", "message": "Invalid credentials"}
-        }"#;
-        let resp: SsoResponse = serde_json::from_str(json).unwrap();
-        let status = resp.response_status.unwrap();
-        assert_eq!(status.response_type, "FAIL");
-        assert_eq!(status.message, "Invalid credentials");
+    fn test_extract_client_id_from_jwt() {
+        let payload = URL_SAFE_NO_PAD.encode(r#"{"client_id":"GARMIN_CONNECT_MOBILE_ANDROID_DI"}"#);
+        let jwt = format!("header.{}.sig", payload);
+        assert_eq!(
+            SsoClient::extract_client_id_from_jwt(&jwt),
+            Some("GARMIN_CONNECT_MOBILE_ANDROID_DI".to_string())
+        );
     }
 
     #[test]
-    fn test_parse_missing_response_status() {
-        // Handles unexpected/empty JSON gracefully
-        let json = r#"{}"#;
-        let resp: SsoResponse = serde_json::from_str(json).unwrap();
-        assert!(resp.response_status.is_none());
-        assert!(resp.service_ticket_id.is_none());
+    fn test_body_is_429() {
+        let body = r#"{"error":{"status-code":"429","message":"{}","request-id":"abc"}}"#;
+        assert!(SsoClient::body_is_429(body));
+    }
+
+    #[test]
+    fn test_extract_widget_ticket() {
+        let html = r#"<html><body><a href="embed?ticket=ST-abc123">continue</a></body></html>"#;
+        assert_eq!(
+            SsoClient::extract_widget_ticket(html),
+            Some("ST-abc123".to_string())
+        );
     }
 }

--- a/crates/garmin-cli/src/client/tokens.rs
+++ b/crates/garmin-cli/src/client/tokens.rs
@@ -52,6 +52,8 @@ pub struct OAuth2Token {
     pub refresh_token_expires_in: i64,
     #[serde(default)]
     pub refresh_token_expires_at: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_id: Option<String>,
 }
 
 impl OAuth2Token {
@@ -63,6 +65,10 @@ impl OAuth2Token {
 
     /// Check if the refresh token has expired.
     pub fn is_refresh_expired(&self) -> bool {
+        if self.refresh_token_expires_at <= 0 {
+            return false;
+        }
+
         let now = Utc::now().timestamp();
         self.refresh_token_expires_at < now
     }
@@ -129,6 +135,7 @@ mod tests {
             expires_at: 0, // Expired (epoch)
             refresh_token_expires_in: 86400,
             refresh_token_expires_at: Utc::now().timestamp() + 86400,
+            client_id: None,
         };
 
         assert!(expired_token.is_expired());
@@ -146,6 +153,7 @@ mod tests {
             expires_at: Utc::now().timestamp() + 3600, // 1 hour from now
             refresh_token_expires_in: 86400,
             refresh_token_expires_at: Utc::now().timestamp() + 86400,
+            client_id: None,
         };
 
         assert!(!valid_token.is_expired());
@@ -162,7 +170,8 @@ mod tests {
             expires_in: 3600,
             expires_at: Utc::now().timestamp() + 3600,
             refresh_token_expires_in: 86400,
-            refresh_token_expires_at: 0, // Refresh token expired
+            refresh_token_expires_at: Utc::now().timestamp() - 1,
+            client_id: None,
         };
 
         assert!(token.is_refresh_expired());
@@ -180,6 +189,7 @@ mod tests {
             expires_at: Utc::now().timestamp() + 3600,
             refresh_token_expires_in: 86400,
             refresh_token_expires_at: Utc::now().timestamp() + 86400,
+            client_id: None,
         };
 
         assert_eq!(token.authorization_header(), "Bearer my_access_token");
@@ -197,11 +207,30 @@ mod tests {
             expires_at: 1700000000,
             refresh_token_expires_in: 86400,
             refresh_token_expires_at: 1700086400,
+            client_id: None,
         };
 
         let json = serde_json::to_string(&token).unwrap();
         let deserialized: OAuth2Token = serde_json::from_str(&json).unwrap();
 
         assert_eq!(token, deserialized);
+    }
+
+    #[test]
+    fn test_oauth2_token_refresh_without_expiry_metadata() {
+        let token = OAuth2Token {
+            scope: "test".to_string(),
+            jti: "jti123".to_string(),
+            token_type: "Bearer".to_string(),
+            access_token: "access123".to_string(),
+            refresh_token: "refresh123".to_string(),
+            expires_in: 3600,
+            expires_at: Utc::now().timestamp() + 3600,
+            refresh_token_expires_in: 0,
+            refresh_token_expires_at: 0,
+            client_id: Some("client-id".to_string()),
+        };
+
+        assert!(!token.is_refresh_expired());
     }
 }

--- a/crates/garmin-cli/src/config/credentials.rs
+++ b/crates/garmin-cli/src/config/credentials.rs
@@ -194,6 +194,7 @@ mod tests {
             expires_at: Utc::now().timestamp() + 3600,
             refresh_token_expires_in: 86400,
             refresh_token_expires_at: Utc::now().timestamp() + 86400,
+            client_id: None,
         }
     }
 

--- a/crates/garmin-cli/src/sync/mod.rs
+++ b/crates/garmin-cli/src/sync/mod.rs
@@ -2276,6 +2276,7 @@ mod tests {
             expires_at: Utc::now().timestamp() + 3600,
             refresh_token_expires_in: 86400,
             refresh_token_expires_at: Utc::now().timestamp() + 86400,
+            client_id: None,
         }
     }
 

--- a/crates/garmin-cli/tests/api_integration_tests.rs
+++ b/crates/garmin-cli/tests/api_integration_tests.rs
@@ -20,6 +20,7 @@ fn test_token() -> OAuth2Token {
         expires_at: chrono::Utc::now().timestamp() + 3600,
         refresh_token_expires_in: 86400,
         refresh_token_expires_at: chrono::Utc::now().timestamp() + 86400,
+        client_id: None,
     }
 }
 


### PR DESCRIPTION
Garmin changed its auth behavior so browser login success no longer implies that the mobile JSON endpoint used by the CLI will accept the same request sequence. Users could sign in through the browser while garmin auth login failed with a synthetic 429 from Garmin SSO, which left the CLI stuck on a request shape that used to work but no longer matches Garmin current non-browser acceptance rules.

Replace the single garth-style mobile login path with a layered auth strategy. Try the iOS mobile JSON flow first, then the embedded widget flow, then the portal flow, and keep their failures separate so we can tell bad credentials apart from Cloudflare or WAF rejection. When a strategy returns a service ticket, exchange it for DI OAuth2 tokens using Garmin native mobile headers and several DI client ids, then persist the issuing client id so later refreshes can reuse the same DI identity. Keep the legacy OAuth1 to OAuth2 exchange as a fallback for older saved sessions and for environments where the DI exchange still fails.

Also move authenticated API requests closer to current mobile client behavior by sending the native Garmin headers, and relax refresh token expiry handling for DI sessions that omit refresh expiry metadata. Add the small token and parser test updates needed for the new auth metadata while keeping the rest of the API surface unchanged.

The DI OAuth flow itself is source-backed. Garmin official OAuth2 PKCE documentation covers the di-oauth2-service token and refresh endpoints, and python-garminconnect (super useful resource, the Android idea is from there) documents that the old garth based OAuth and cookie flow no longer works and now uses DI bearer tokens. The exact X-Garmin mobile headers added here are not described in a public Garmin spec, so they are a best effort approximation of current native client identity rather than a packet captured or officially documented header contract.

I considered three narrower fixes, but none felt super good. Retrying the existing mobile api login request or only improving the 429 error text would make the failure nicer but would not change the request shape Garmin is rejecting. Switching entirely to one browser-style flow would still leave the CLI exposed to whichever SSO surface Garmin blocks next and would not help refresh stored sessions. Dropping the legacy OAuth1 path immediately would force every existing session to re-authenticate and would remove the only working refresh fallback for older tokens.

Codex helped with a lot of the code. Works well in my testing (managed to log-in), but you probably know the codebase better and feel free to start from scratch if you trust your agent more :)