### PR TITLE
Display Garmin sleep user notes

### DIFF
--- a/crates/garmin-cli/src/cli/commands/health.rs
+++ b/crates/garmin-cli/src/cli/commands/health.rs
@@ -1140,6 +1140,14 @@ fn print_sleep_summary(data: &serde_json::Value) {
     {
         println!("Sleep Score:  {}", score);
     }
+
+    // Subjective note added in the Garmin mobile app, when present
+    if let Some(note) = data.get("userNote").and_then(|v| v.as_str()) {
+        let note = note.trim();
+        if !note.is_empty() {
+            println!("User Note:    {}", note);
+        }
+    }
 }
 
 /// Get lactate threshold data

--- a/crates/garmin-cli/tests/api_integration_tests.rs
+++ b/crates/garmin-cli/tests/api_integration_tests.rs
@@ -143,6 +143,34 @@ mod sleep_tests {
     }
 
     #[tokio::test]
+    async fn test_sleep_user_note_parsing() {
+        let mock_server = MockServer::start().await;
+        let fixture = include_str!("fixtures/sleep_2025-12-04.json");
+
+        Mock::given(method("GET"))
+            .and(path("/wellness-service/wellness/dailySleepData/TestUser"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(fixture))
+            .mount(&mock_server)
+            .await;
+
+        let client = test_client(&mock_server);
+        let token = test_token();
+
+        let result: serde_json::Value = client
+            .get_json(
+                &token,
+                "/wellness-service/wellness/dailySleepData/TestUser?date=2025-12-04",
+            )
+            .await
+            .expect("Failed to get sleep data");
+
+        // The subjective note added in the Garmin mobile app is read from
+        // dailySleepDTO.userNote and surfaced in the sleep summary.
+        let note = result["dailySleepDTO"]["userNote"].as_str().unwrap();
+        assert_eq!(note, "Late caffeine, restless night.");
+    }
+
+    #[tokio::test]
     async fn test_sleep_total_calculation() {
         let fixture: serde_json::Value =
             serde_json::from_str(include_str!("fixtures/sleep_2025-12-04.json")).unwrap();

--- a/crates/garmin-cli/tests/fixtures/sleep_2025-12-04.json
+++ b/crates/garmin-cli/tests/fixtures/sleep_2025-12-04.json
@@ -27,7 +27,8 @@
       }
     },
     "sleepStartTimestampGMT": 1733270400000,
-    "sleepEndTimestampGMT": 1733302320000
+    "sleepEndTimestampGMT": 1733302320000,
+    "userNote": "Late caffeine, restless night."
   },
   "avgOvernightHrv": 58.0,
   "bodyBatteryChange": 55


### PR DESCRIPTION
## Summary

Surfaces the subjective sleep note added in the Garmin mobile app. Garmin stores it as `dailySleepDTO.userNote` on the `/wellness-service/wellness/dailySleepData/...` response. When present and non-empty, `garmin health sleep` now appends it after the sleep score:

```
Sleep Summary
------------------------------
Total Sleep:  8h55m
Deep Sleep:   1h29m
Light Sleep:  4h36m
REM Sleep:    2h50m
Awake:        0h02m
Sleep Score:  89
User Note:    Late caffeine, restless night.
```

Absent or empty notes print nothing.

## Background

`userNote` was verified against a real Garmin Connect sleep record created in the mobile app. The print function (`print_sleep_summary`) already receives the unwrapped `dailySleepDTO`, so reading `userNote` is a localized change.

For reference: **activity** notes map to the top-level `description` field, which `garmin activities get <id>` already shows via its raw-JSON output (no change needed here).

## Follow-ups

- Persisting the sleep note into the synced Parquet data lake (separate PR).
- Activity note `get/set/clear` commands (separate PR).

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` — adds `test_sleep_user_note_parsing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)