### PR TITLE
Persist sleep user note in the synced data lake

### DIFF
--- a/crates/garmin-cli/src/db/models.rs
+++ b/crates/garmin-cli/src/db/models.rs
@@ -79,6 +79,8 @@ pub struct DailyHealth {
     pub light_sleep_seconds: Option<i32>,
     pub rem_sleep_seconds: Option<i32>,
     pub sleep_score: Option<i32>,
+    /// Subjective sleep note added in the Garmin mobile app (dailySleepDTO.userNote)
+    pub sleep_note: Option<String>,
     pub avg_stress: Option<i32>,
     pub max_stress: Option<i32>,
     pub body_battery_start: Option<i32>,

--- a/crates/garmin-cli/src/storage/parquet.rs
+++ b/crates/garmin-cli/src/storage/parquet.rs
@@ -786,6 +786,7 @@ impl ParquetStore {
             .iter()
             .map(|r| r.raw_json.as_ref().map(|j| j.to_string()))
             .collect();
+        let sleep_note: StringArray = records.iter().map(|r| r.sleep_note.as_deref()).collect();
 
         let schema = Arc::new(Schema::new(vec![
             Field::new("id", DataType::Int64, true),
@@ -816,6 +817,7 @@ impl ParquetStore {
             Field::new("moderate_intensity_min", DataType::Int32, true),
             Field::new("vigorous_intensity_min", DataType::Int32, true),
             Field::new("raw_json", DataType::Utf8, true),
+            Field::new("sleep_note", DataType::Utf8, true),
         ]));
 
         RecordBatch::try_new(
@@ -849,6 +851,7 @@ impl ParquetStore {
                 Arc::new(moderate_intensity_min),
                 Arc::new(vigorous_intensity_min),
                 Arc::new(raw_json),
+                Arc::new(sleep_note),
             ],
         )
         .map_err(|e| GarminError::Database(format!("Failed to create record batch: {}", e)))
@@ -998,6 +1001,11 @@ impl ParquetStore {
             .as_any()
             .downcast_ref::<StringArray>()
             .unwrap();
+        // Looked up by name for backward compatibility: Parquet files written
+        // before this column existed simply yield None.
+        let sleep_note = batch
+            .column_by_name("sleep_note")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>());
 
         let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
 
@@ -1025,6 +1033,8 @@ impl ParquetStore {
                     .is_valid(i)
                     .then(|| rem_sleep_seconds.value(i)),
                 sleep_score: sleep_score.is_valid(i).then(|| sleep_score.value(i)),
+                sleep_note: sleep_note
+                    .and_then(|arr| arr.is_valid(i).then(|| arr.value(i).to_string())),
                 avg_stress: avg_stress.is_valid(i).then(|| avg_stress.value(i)),
                 max_stress: max_stress.is_valid(i).then(|| max_stress.value(i)),
                 body_battery_start: body_battery_start
@@ -1933,6 +1943,7 @@ mod tests {
             light_sleep_seconds: Some(14400),
             rem_sleep_seconds: Some(7200),
             sleep_score: Some(85),
+            sleep_note: Some("Felt rested.".to_string()),
             avg_stress: Some(30),
             max_stress: Some(75),
             body_battery_start: Some(95),
@@ -1958,6 +1969,7 @@ mod tests {
 
         assert_eq!(read_back.len(), 1);
         assert_eq!(read_back[0].steps, Some(10000));
+        assert_eq!(read_back[0].sleep_note.as_deref(), Some("Felt rested."));
         assert_eq!(
             read_back[0].date,
             NaiveDate::from_ymd_opt(2024, 12, 15).unwrap()
@@ -1987,6 +1999,7 @@ mod tests {
             light_sleep_seconds: None,
             rem_sleep_seconds: None,
             sleep_score: None,
+            sleep_note: None,
             avg_stress: None,
             max_stress: None,
             body_battery_start: None,

--- a/crates/garmin-cli/src/sync/mod.rs
+++ b/crates/garmin-cli/src/sync/mod.rs
@@ -1455,6 +1455,17 @@ fn parse_sleep_metrics(value: Option<&serde_json::Value>) -> SleepMetrics {
     (total, deep, light, rem, score)
 }
 
+/// Extract the subjective sleep note (dailySleepDTO.userNote) added in the
+/// Garmin mobile app. Returns None when absent or empty after trimming.
+fn parse_sleep_note(value: Option<&serde_json::Value>) -> Option<String> {
+    let dto = value.and_then(|v| v.get("dailySleepDTO")).or(value)?;
+    dto.get("userNote")
+        .and_then(|v| v.as_str())
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
 fn parse_hrv_metrics(
     value: Option<&serde_json::Value>,
 ) -> (Option<i32>, Option<i32>, Option<String>) {
@@ -1726,6 +1737,7 @@ async fn fetch_task_data(
 
             let (sleep_total, deep_sleep, light_sleep, rem_sleep, sleep_score) =
                 parse_sleep_metrics(sleep_data.as_ref());
+            let sleep_note = parse_sleep_note(sleep_data.as_ref());
             let (hrv_weekly_avg, hrv_last_night, hrv_status) = parse_hrv_metrics(hrv_data.as_ref());
 
             let record = DailyHealth {
@@ -1766,6 +1778,7 @@ async fn fetch_task_data(
                 light_sleep_seconds: light_sleep,
                 rem_sleep_seconds: rem_sleep,
                 sleep_score,
+                sleep_note,
                 avg_stress: health
                     .get("averageStressLevel")
                     .and_then(|v| v.as_i64())
@@ -2344,6 +2357,7 @@ mod tests {
             light_sleep_seconds: None,
             rem_sleep_seconds: None,
             sleep_score: None,
+            sleep_note: None,
             avg_stress: None,
             max_stress: None,
             body_battery_start: None,
@@ -2517,6 +2531,10 @@ mod tests {
                 assert_eq!(record.light_sleep_seconds, Some(15300));
                 assert_eq!(record.rem_sleep_seconds, Some(8520));
                 assert_eq!(record.sleep_score, Some(88));
+                assert_eq!(
+                    record.sleep_note.as_deref(),
+                    Some("Late caffeine, restless night.")
+                );
                 assert_eq!(record.hrv_weekly_avg, Some(65));
                 assert_eq!(record.hrv_last_night, Some(68));
                 assert_eq!(record.hrv_status.as_deref(), Some("BALANCED"));

--- a/crates/garmin-cli/tests/fixtures/sleep_2025-12-04.json
+++ b/crates/garmin-cli/tests/fixtures/sleep_2025-12-04.json
@@ -27,7 +27,8 @@
       }
     },
     "sleepStartTimestampGMT": 1733270400000,
-    "sleepEndTimestampGMT": 1733302320000
+    "sleepEndTimestampGMT": 1733302320000,
+    "userNote": "Late caffeine, restless night."
   },
   "avgOvernightHrv": 58.0,
   "bodyBatteryChange": 55


### PR DESCRIPTION
## Summary

The sync pipeline fetched the sleep response (`/wellness-service/wellness/dailySleepData/...`) and parsed its metrics, but discarded everything else — so the subjective sleep note (`dailySleepDTO.userNote`) never reached the Parquet data lake and could not be queried alongside the rest of the health data.

This adds a typed `sleep_note` column to `DailyHealth`, populated during sync via a new `parse_sleep_note` helper. It becomes queryable with DuckDB:

```sql
SELECT date, sleep_note
FROM '~/.local/share/garmin/daily_health/*.parquet'
WHERE sleep_note IS NOT NULL;
```

## Notes for reviewers

- **Backward compatibility:** the column is appended after `raw_json` in the Parquet schema and read back via `column_by_name("sleep_note")`, so Parquet files written before this column existed degrade gracefully to `None` (rather than panicking on a fixed column index). Historical notes appear after a re-sync / `--backfill`.
- Uses a **dedicated typed column** rather than dumping raw sleep JSON, so it's directly queryable.

## Background

`dailySleepDTO.userNote` was verified against a real Garmin Connect sleep record created in the mobile app. (The read-side display of this field in `garmin health sleep` is a separate PR.)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` — extends the daily-health sync test and Parquet round-trip test to assert `sleep_note`

🤖 Generated with [Claude Code](https://claude.com/claude-code)