### PR TITLE
Add activity note get/set/clear commands

### DIFF
--- a/crates/garmin-cli/src/cli/commands/activities.rs
+++ b/crates/garmin-cli/src/cli/commands/activities.rs
@@ -77,6 +77,61 @@ pub async fn get(id: u64, profile: Option<String>) -> Result<()> {
     Ok(())
 }
 
+/// Print an activity's note. Garmin's mobile app calls this a "note"; the API
+/// stores it as the top-level `description` field. Prints only the note text to
+/// stdout (script-friendly), or nothing when no note is set.
+pub async fn note_get(id: u64, profile: Option<String>) -> Result<()> {
+    let store = CredentialStore::new(profile)?;
+    let (_, oauth2) = refresh_token(&store).await?;
+
+    let client = GarminClient::new();
+    let path = format!("/activity-service/activity/{}", id);
+
+    let activity: serde_json::Value = client.get_json(&oauth2, &path).await?;
+
+    if let Some(note) = activity.get("description").and_then(|v| v.as_str()) {
+        let note = note.trim();
+        if !note.is_empty() {
+            println!("{}", note);
+        }
+    }
+
+    Ok(())
+}
+
+/// Set an activity's note (Garmin activity `description`).
+pub async fn note_set(id: u64, note: &str, profile: Option<String>) -> Result<()> {
+    set_description(id, note, profile).await
+}
+
+/// Clear an activity's note (Garmin activity `description`).
+pub async fn note_clear(id: u64, profile: Option<String>) -> Result<()> {
+    set_description(id, "", profile).await
+}
+
+/// PUT the activity description. An empty string clears the note.
+async fn set_description(id: u64, description: &str, profile: Option<String>) -> Result<()> {
+    let store = CredentialStore::new(profile)?;
+    let (_, oauth2) = refresh_token(&store).await?;
+
+    let client = GarminClient::new();
+    let path = format!("/activity-service/activity/{}", id);
+    let body = serde_json::json!({
+        "activityId": id,
+        "description": description,
+    });
+
+    client.put_json(&oauth2, &path, &body).await?;
+
+    if description.is_empty() {
+        println!("Cleared note for activity {}.", id);
+    } else {
+        println!("Updated note for activity {}.", id);
+    }
+
+    Ok(())
+}
+
 /// Download activity file
 pub async fn download(
     id: u64,

--- a/crates/garmin-cli/src/cli/commands/mod.rs
+++ b/crates/garmin-cli/src/cli/commands/mod.rs
@@ -8,7 +8,8 @@ pub mod weight;
 
 pub use activities::{
     download as download_activity, get as get_activity, list as list_activities,
-    upload as upload_activity,
+    note_clear as activity_note_clear, note_get as activity_note_get,
+    note_set as activity_note_set, upload as upload_activity,
 };
 pub use auth::{login, logout, status};
 pub use devices::{get as get_device, history as device_history, list as list_devices};

--- a/crates/garmin-cli/src/client/api.rs
+++ b/crates/garmin-cli/src/client/api.rs
@@ -115,6 +115,36 @@ impl GarminClient {
         })
     }
 
+    /// Make an authenticated PUT request with JSON body
+    pub async fn put_json(
+        &self,
+        token: &OAuth2Token,
+        path: &str,
+        body: &serde_json::Value,
+    ) -> Result<serde_json::Value> {
+        let url = self.build_url(path);
+        let headers = self.build_headers(token);
+
+        let response = self
+            .client
+            .put(&url)
+            .headers(headers)
+            .json(body)
+            .send()
+            .await
+            .map_err(GarminError::Http)?;
+
+        let response = self.handle_response_status(response).await?;
+        // Garmin may answer an activity update with an empty body; treat that as success.
+        let text = response.text().await.unwrap_or_default();
+        if text.trim().is_empty() {
+            return Ok(serde_json::Value::Null);
+        }
+        serde_json::from_str(&text).map_err(|e| {
+            GarminError::invalid_response(format!("Failed to parse JSON response: {}", e))
+        })
+    }
+
     /// Make an authenticated GET request and return raw bytes (for file downloads)
     pub async fn download(&self, token: &OAuth2Token, path: &str) -> Result<Bytes> {
         let response = self.get(token, path).await?;

--- a/crates/garmin-cli/src/main.rs
+++ b/crates/garmin-cli/src/main.rs
@@ -93,6 +93,32 @@ enum ActivityCommands {
         /// File path to upload
         file: String,
     },
+    /// Read or edit an activity note (maps to the Garmin activity `description`)
+    Note {
+        #[command(subcommand)]
+        command: NoteCommands,
+    },
+}
+
+#[derive(Subcommand)]
+enum NoteCommands {
+    /// Print an activity's note
+    Get {
+        /// Activity ID
+        id: u64,
+    },
+    /// Set an activity's note
+    Set {
+        /// Activity ID
+        id: u64,
+        /// Note text
+        note: String,
+    },
+    /// Clear an activity's note
+    Clear {
+        /// Activity ID
+        id: u64,
+    },
 }
 
 #[derive(Subcommand)]
@@ -374,6 +400,13 @@ async fn main() -> garmin_cli::Result<()> {
             ActivityCommands::Upload { file } => {
                 commands::upload_activity(&file, cli.profile).await
             }
+            ActivityCommands::Note { command } => match command {
+                NoteCommands::Get { id } => commands::activity_note_get(id, cli.profile).await,
+                NoteCommands::Set { id, note } => {
+                    commands::activity_note_set(id, &note, cli.profile).await
+                }
+                NoteCommands::Clear { id } => commands::activity_note_clear(id, cli.profile).await,
+            },
         },
         Commands::Health { command } => match command {
             HealthCommands::Summary { date } => commands::summary(date, cli.profile).await,

--- a/crates/garmin-cli/tests/api_integration_tests.rs
+++ b/crates/garmin-cli/tests/api_integration_tests.rs
@@ -1393,3 +1393,102 @@ mod error_handling_tests {
         assert!(result.is_err());
     }
 }
+
+mod activity_note_tests {
+    use super::*;
+    use wiremock::matchers::body_json;
+
+    // Activity notes are read from / written to the top-level `description`
+    // field on /activity-service/activity/{id}. Verified against a real Garmin
+    // Connect activity note created in the mobile app.
+
+    #[tokio::test]
+    async fn test_get_activity_description() {
+        let mock_server = MockServer::start().await;
+        let body = serde_json::json!({
+            "activityId": 22987587132u64,
+            "description": "War e-bike was ich mir geliehen hatte."
+        });
+
+        Mock::given(method("GET"))
+            .and(path("/activity-service/activity/22987587132"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+            .mount(&mock_server)
+            .await;
+
+        let client = test_client(&mock_server);
+        let token = test_token();
+
+        let activity: serde_json::Value = client
+            .get_json(&token, "/activity-service/activity/22987587132")
+            .await
+            .expect("GET should succeed");
+
+        assert_eq!(
+            activity["description"].as_str(),
+            Some("War e-bike was ich mir geliehen hatte.")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_put_activity_note_sends_description() {
+        let mock_server = MockServer::start().await;
+        let expected_body = serde_json::json!({
+            "activityId": 22987587132u64,
+            "description": "Felt controlled; left calf slightly tight."
+        });
+
+        Mock::given(method("PUT"))
+            .and(path("/activity-service/activity/22987587132"))
+            .and(header("Authorization", "Bearer test-access-token"))
+            .and(body_json(&expected_body))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&mock_server)
+            .await;
+
+        let client = test_client(&mock_server);
+        let token = test_token();
+
+        // An empty (204) response body is treated as success and yields Null.
+        let result = client
+            .put_json(
+                &token,
+                "/activity-service/activity/22987587132",
+                &expected_body,
+            )
+            .await
+            .expect("PUT should succeed");
+
+        assert!(result.is_null());
+    }
+
+    #[tokio::test]
+    async fn test_clear_activity_note_sends_empty_description() {
+        let mock_server = MockServer::start().await;
+        let expected_body = serde_json::json!({
+            "activityId": 22987587132u64,
+            "description": ""
+        });
+
+        Mock::given(method("PUT"))
+            .and(path("/activity-service/activity/22987587132"))
+            .and(body_json(&expected_body))
+            .respond_with(ResponseTemplate::new(200).set_body_string(""))
+            .mount(&mock_server)
+            .await;
+
+        let client = test_client(&mock_server);
+        let token = test_token();
+
+        let result = client
+            .put_json(
+                &token,
+                "/activity-service/activity/22987587132",
+                &expected_body,
+            )
+            .await
+            .expect("clear should succeed");
+
+        assert!(result.is_null());
+    }
+}


### PR DESCRIPTION
## Summary

Adds scriptable access to activity notes. Garmin's mobile app calls it a "note"; the API stores it as the top-level `description` on `/activity-service/activity/{id}`. The user-facing command is `note`, documented as mapping to `description`:

```bash
garmin activities note get   <id>
garmin activities note set   <id> "Felt controlled; left calf slightly tight."
garmin activities note clear <id>
```

- `note get` prints only the note text to stdout (script-friendly), nothing when unset.
- `note set` / `note clear` PUT `{"activityId": <id>, "description": "<text-or-empty>"}`; clear sends an empty string.
- Adds a `put_json` helper to the API client, mirroring `post_json` (empty / `204` responses are treated as success).

This follows the existing write precedent of `garmin activities upload`.

## ⚠️ Note on write verification

The read paths (`description` from `GET /activity-service/activity/{id}`) are verified against a real Garmin Connect activity note created in the mobile app.

The **write** payload shape is derived from the `garminconnect` Python wrapper's `set_activity_name` and is covered by wiremock tests, but has **not yet been confirmed against a live account**. Maintainers may wish to verify the `PUT` payload before relying on writes. Happy to confirm and follow up.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` — adds wiremock tests for GET `description`, PUT note, and clear-note

🤖 Generated with [Claude Code](https://claude.com/claude-code)