### PR TITLE
fix: parse calories and heart rate fields as floats

### DIFF
--- a/crates/garmin-cli/src/sync/mod.rs
+++ b/crates/garmin-cli/src/sync/mod.rs
@@ -1959,15 +1959,15 @@ fn parse_activity(activity: &serde_json::Value, profile_id: i32) -> Result<Activ
         distance_m: activity.get("distance").and_then(|v| v.as_f64()),
         calories: activity
             .get("calories")
-            .and_then(|v| v.as_i64())
+            .and_then(|v| v.as_f64())
             .map(|v| v as i32),
         avg_hr: activity
             .get("averageHR")
-            .and_then(|v| v.as_i64())
+            .and_then(|v| v.as_f64())
             .map(|v| v as i32),
         max_hr: activity
             .get("maxHR")
-            .and_then(|v| v.as_i64())
+            .and_then(|v| v.as_f64())
             .map(|v| v as i32),
         avg_speed: activity.get("averageSpeed").and_then(|v| v.as_f64()),
         max_speed: activity.get("maxSpeed").and_then(|v| v.as_f64()),


### PR DESCRIPTION
These fields are represented as floats in JSON which `as_i64()` maps to None.

May also apply to `avg_power` and `normalized_power` but my device doesn't provide these fields.

Before:
```
memory D SELECT calories, avg_hr, max_hr FROM '~/Library/Application Support/garmin/activities/*.parquet' LIMIT 1;
calories = NULL
  avg_hr = NULL
  max_hr = NULL
```

After:
```
memory D SELECT calories, avg_hr, max_hr FROM '~/Library/Application Support/garmin/activities/*.parquet' LIMIT 1;
calories = 341
  avg_hr = 141
  max_hr = 159
```