### PR TITLE
feat(sync): show worker progress during sync

### DIFF
--- a/crates/garmin-cli/src/sync/mod.rs
+++ b/crates/garmin-cli/src/sync/mod.rs
@@ -25,7 +25,7 @@ use crate::db::models::{
 };
 use crate::storage::{ParquetStore, Storage, SyncDb};
 use crate::{GarminError, Result};
-use std::io::{self, Write};
+use std::io::{self, IsTerminal, Write};
 
 pub use progress::{PlanningStep, SharedProgress, SyncProgress};
 pub use rate_limiter::{RateLimiter, SharedRateLimiter};
@@ -602,6 +602,7 @@ impl SyncEngine {
     ) -> Result<SyncStats> {
         // Bounded channel for backpressure (100 items)
         let (tx, rx) = mpsc::channel::<SyncData>(100);
+        progress.set_worker_slots(opts.concurrency);
 
         // Shared resources
         let parquet = Arc::new(self.storage.parquet.clone());
@@ -1060,11 +1061,26 @@ fn print_sync_errors(progress: &SyncProgress) {
 }
 
 async fn run_progress_reporter(progress: SharedProgress) {
+    let interactive = std::io::stdout().is_terminal();
+    let mut rendered_lines = 0usize;
+
     loop {
-        progress.print_simple_status();
+        if interactive {
+            let lines = progress.status_lines();
+            if rendered_lines > 0 {
+                print!("\x1b[{}A", rendered_lines);
+            }
+            for line in &lines {
+                println!("\x1b[2K{}", line);
+            }
+            rendered_lines = lines.len();
+            let _ = io::stdout().flush();
+        }
 
         if progress.should_shutdown() || progress.is_complete() {
-            println!();
+            if interactive {
+                println!();
+            }
             break;
         }
 
@@ -1292,7 +1308,7 @@ fn record_write_failure(data: &SyncData, progress: &SyncProgress, error: &str) {
 
 /// Producer loop: fetches data from Garmin API and sends to channel
 async fn producer_loop(
-    _id: usize,
+    id: usize,
     queue: SharedTaskQueue,
     tx: mpsc::Sender<SyncData>,
     context: ProducerContext,
@@ -1332,6 +1348,16 @@ async fn producer_loop(
 
         // Update progress display
         update_progress_for_task(&task, &context.progress);
+        if let Some((stream, item)) = worker_task_details(&task) {
+            context.progress.set_worker_task(
+                "P",
+                id,
+                Some(task_id),
+                stream,
+                item,
+                "checking cache",
+            );
+        }
 
         // Skip tasks that already exist unless forcing
         if !context.force {
@@ -1366,13 +1392,18 @@ async fn producer_loop(
                     s.completed += 1;
                 }
                 context.in_flight.fetch_sub(1, Ordering::Relaxed);
+                context.progress.clear_worker("P", id);
                 continue;
             }
         }
 
         // Acquire rate limiter permit
+        context
+            .progress
+            .set_worker_status("P", id, "rate limit wait");
         let _permit = context.rate_limiter.acquire().await;
         context.progress.record_request();
+        context.progress.set_worker_status("P", id, "fetching");
 
         // Fetch data based on task type
         let result = fetch_task_data(
@@ -1395,8 +1426,10 @@ async fn producer_loop(
                     let _ = queue
                         .mark_failed(task_id, claim_attempt, "Consumer channel closed", backoff)
                         .await;
+                    context.progress.clear_worker("P", id);
                     break;
                 }
+                context.progress.clear_worker("P", id);
             }
             Err(GarminError::RateLimited) => {
                 context.rate_limiter.on_rate_limit();
@@ -1413,6 +1446,7 @@ async fn producer_loop(
                     s.rate_limited += 1;
                 }
                 context.in_flight.fetch_sub(1, Ordering::Relaxed);
+                context.progress.clear_worker("P", id);
             }
             Err(e) => {
                 let backoff = Duration::seconds(60);
@@ -1429,8 +1463,32 @@ async fn producer_loop(
                     s.failed += 1;
                 }
                 context.in_flight.fetch_sub(1, Ordering::Relaxed);
+                context.progress.clear_worker("P", id);
             }
         }
+    }
+}
+
+fn worker_task_details(task: &SyncTask) -> Option<(&'static str, String)> {
+    match &task.task_type {
+        SyncTaskType::Activities { start, limit, .. } => {
+            Some(("Activities", format!("{}-{}", start, start + limit)))
+        }
+        SyncTaskType::DownloadGpx {
+            activity_id,
+            activity_name,
+            activity_date,
+        } => {
+            let name = activity_name.as_deref().unwrap_or("activity");
+            let item = activity_date
+                .as_deref()
+                .map(|date| format!("{} {}", date, name))
+                .unwrap_or_else(|| format!("{} ({})", name, activity_id));
+            Some(("GPX", item))
+        }
+        SyncTaskType::DailyHealth { date } => Some(("Health", date.to_string())),
+        SyncTaskType::Performance { date } => Some(("Performance", date.to_string())),
+        _ => None,
     }
 }
 
@@ -2208,7 +2266,7 @@ fn parse_f64_stream_value(value: &str) -> Option<f64> {
 
 /// Consumer loop: receives data from channel and writes to Parquet
 async fn consumer_loop(
-    _id: usize,
+    id: usize,
     rx: Arc<TokioMutex<mpsc::Receiver<SyncData>>>,
     parquet: Arc<ParquetStore>,
     queue: SharedTaskQueue,
@@ -2227,6 +2285,9 @@ async fn consumer_loop(
             Some(d) => d,
             None => break, // Channel closed, all producers done
         };
+
+        let (task_id, stream, item) = consumer_task_details(&data);
+        progress.set_worker_task("C", id, Some(task_id), stream, item, "writing");
 
         // Process and write data
         let result = match &data {
@@ -2361,6 +2422,7 @@ async fn consumer_loop(
                     .await
                 {
                     eprintln!("Failed to mark task completed: {}", e);
+                    progress.clear_worker("C", id);
                     in_flight.fetch_sub(1, Ordering::Relaxed);
                     continue;
                 }
@@ -2400,6 +2462,7 @@ async fn consumer_loop(
                     _ => {}
                 }
                 in_flight.fetch_sub(1, Ordering::Relaxed);
+                progress.clear_worker("C", id);
             }
             Err(e) => {
                 // Mark task failed
@@ -2421,8 +2484,36 @@ async fn consumer_loop(
                 record_write_failure(&data, &progress, &error_msg);
                 eprintln!("Write error for {}: {}", task_type, error_msg);
                 in_flight.fetch_sub(1, Ordering::Relaxed);
+                progress.clear_worker("C", id);
             }
         }
+    }
+}
+
+fn consumer_task_details(data: &SyncData) -> (i64, &'static str, String) {
+    match data {
+        SyncData::Activities {
+            records, task_id, ..
+        } => (
+            *task_id,
+            "Activities",
+            records
+                .first()
+                .map(|record| record.activity_id.to_string())
+                .unwrap_or_else(|| "page".to_string()),
+        ),
+        SyncData::Health {
+            record, task_id, ..
+        } => (*task_id, "Health", record.date.to_string()),
+        SyncData::Performance {
+            record, task_id, ..
+        } => (*task_id, "Performance", record.date.to_string()),
+        SyncData::TrackPoints {
+            activity_id,
+            date,
+            task_id,
+            ..
+        } => (*task_id, "GPX", format!("{} ({})", date, activity_id)),
     }
 }
 

--- a/crates/garmin-cli/src/sync/progress.rs
+++ b/crates/garmin-cli/src/sync/progress.rs
@@ -44,6 +44,24 @@ pub struct ErrorEntry {
     pub error: String,
 }
 
+/// The task currently assigned to one producer worker.
+#[derive(Debug, Clone)]
+pub struct WorkerProgress {
+    pub role: &'static str,
+    pub id: usize,
+    pub task_id: Option<i64>,
+    pub stream: &'static str,
+    pub item: String,
+    pub started_at: Instant,
+    pub status: String,
+}
+
+impl WorkerProgress {
+    pub fn elapsed(&self) -> String {
+        format_elapsed(self.started_at.elapsed().as_secs())
+    }
+}
+
 /// Progress tracking for a single data stream
 #[derive(Debug)]
 pub struct StreamProgress {
@@ -207,6 +225,10 @@ pub struct SyncProgress {
     pub planning_step: Mutex<PlanningStep>,
     /// Oldest activity date found during planning
     pub oldest_activity_date: Mutex<Option<String>>,
+    /// Current task for each producer worker
+    workers: Mutex<Vec<WorkerProgress>>,
+    /// Number of producer workers shown in the progress block
+    worker_slots: AtomicU32,
 }
 
 impl SyncProgress {
@@ -231,6 +253,8 @@ impl SyncProgress {
             shutdown: AtomicBool::new(false),
             planning_step: Mutex::new(PlanningStep::FetchingProfile),
             oldest_activity_date: Mutex::new(None),
+            workers: Mutex::new(Vec::new()),
+            worker_slots: AtomicU32::new(0),
         }
     }
 
@@ -357,6 +381,109 @@ impl SyncProgress {
         self.errors.lock().unwrap().clone()
     }
 
+    pub fn set_worker_slots(&self, slots: usize) {
+        self.worker_slots.store(slots as u32, Ordering::Relaxed);
+    }
+
+    pub fn set_worker_task(
+        &self,
+        role: &'static str,
+        id: usize,
+        task_id: Option<i64>,
+        stream: &'static str,
+        item: String,
+        status: impl Into<String>,
+    ) {
+        let mut workers = self.workers.lock().unwrap();
+        let status = status.into();
+        if let Some(worker) = workers
+            .iter_mut()
+            .find(|worker| worker.role == role && worker.id == id)
+        {
+            worker.task_id = task_id;
+            worker.stream = stream;
+            worker.item = item;
+            worker.started_at = Instant::now();
+            worker.status = status;
+        } else {
+            workers.push(WorkerProgress {
+                role,
+                id,
+                task_id,
+                stream,
+                item,
+                started_at: Instant::now(),
+                status,
+            });
+        }
+    }
+
+    pub fn set_worker_status(&self, role: &'static str, id: usize, status: impl Into<String>) {
+        if let Some(worker) = self
+            .workers
+            .lock()
+            .unwrap()
+            .iter_mut()
+            .find(|worker| worker.role == role && worker.id == id)
+        {
+            worker.status = status.into();
+        }
+    }
+
+    pub fn clear_worker(&self, role: &'static str, id: usize) {
+        self.workers
+            .lock()
+            .unwrap()
+            .retain(|worker| worker.role != role || worker.id != id);
+    }
+
+    /// Render the stable-height progress block used by the interactive reporter.
+    pub fn status_lines(&self) -> Vec<String> {
+        let width = terminal_width();
+        let summary = format!(
+            "Act {}/{} | GPX {}/{} | Health {}/{} | Perf {}/{} | elapsed {}",
+            self.activities.get_completed(),
+            self.activities.get_total(),
+            self.gpx.get_completed(),
+            self.gpx.get_total(),
+            self.health.get_completed(),
+            self.health.get_total(),
+            self.performance.get_completed(),
+            self.performance.get_total(),
+            self.elapsed_str(),
+        );
+        let workers = self.workers.lock().unwrap();
+        let slots = self.worker_slots.load(Ordering::Relaxed) as usize;
+        let mut lines = vec![truncate_line(summary, width)];
+
+        for role in ["P", "C"] {
+            for id in 0..slots {
+                let line = match workers
+                    .iter()
+                    .find(|worker| worker.role == role && worker.id == id)
+                {
+                    Some(worker) => format!(
+                        "{}{}  {:<9} #{} {:<24} {:<18} {}",
+                        role,
+                        worker.id,
+                        worker.stream,
+                        worker
+                            .task_id
+                            .map(|task_id| task_id.to_string())
+                            .unwrap_or_else(|| "-".to_string()),
+                        worker.item,
+                        worker.status,
+                        worker.elapsed(),
+                    ),
+                    None => format!("{}{}  idle", role, id),
+                };
+                lines.push(truncate_line(line, width));
+            }
+        }
+
+        lines
+    }
+
     /// Get current task description (finds first active stream)
     pub fn get_current_task(&self) -> Option<String> {
         // Check streams in order of typical processing
@@ -479,25 +606,35 @@ impl SyncProgress {
 
     /// Print a status line for terminal progress reporting.
     pub fn print_simple_status(&self) {
-        let act = &self.activities;
-        let gpx = &self.gpx;
-        let health = &self.health;
-        let perf = &self.performance;
-
-        print!(
-            "\rAct: {}/{} | GPX: {}/{} | Health: {}/{} | Perf: {}/{} | {} ",
-            act.get_completed(),
-            act.get_total(),
-            gpx.get_completed(),
-            gpx.get_total(),
-            health.get_completed(),
-            health.get_total(),
-            perf.get_completed(),
-            perf.get_total(),
-            self.elapsed_str(),
-        );
+        print!("{}", self.status_lines().join("\n"));
         let _ = std::io::Write::flush(&mut std::io::stdout());
     }
+}
+
+fn format_elapsed(secs: u64) -> String {
+    let mins = secs / 60;
+    if mins > 0 {
+        format!("{}m {}s", mins, secs % 60)
+    } else {
+        format!("{}s", secs)
+    }
+}
+
+fn terminal_width() -> usize {
+    std::env::var("COLUMNS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .filter(|width| *width >= 40)
+        .unwrap_or(120)
+}
+
+fn truncate_line(line: String, width: usize) -> String {
+    if line.chars().count() <= width {
+        return line;
+    }
+    let mut result: String = line.chars().take(width.saturating_sub(1)).collect();
+    result.push('~');
+    result
 }
 
 impl Default for SyncProgress {
@@ -564,5 +701,32 @@ mod tests {
         progress.health.complete_one();
 
         assert_eq!(progress.total_completed(), 2);
+    }
+
+    #[test]
+    fn worker_progress_is_visible_and_has_fixed_height() {
+        let progress = SyncProgress::new();
+        progress.set_worker_slots(2);
+        progress.set_worker_task(
+            "P",
+            0,
+            Some(42),
+            "Health",
+            "2026-01-01".to_string(),
+            "fetching",
+        );
+
+        let lines = progress.status_lines();
+        assert_eq!(lines.len(), 5);
+        assert!(lines[1].contains("P0"));
+        assert!(lines[1].contains("fetching"));
+        assert_eq!(lines[2], "P1  idle");
+        assert_eq!(lines[3], "C0  idle");
+        assert_eq!(lines[4], "C1  idle");
+
+        progress.set_worker_status("P", 0, "writing");
+        assert!(progress.status_lines()[1].contains("writing"));
+        progress.clear_worker("P", 0);
+        assert!(progress.status_lines()[1].contains("idle"));
     }
 }


### PR DESCRIPTION
## Summary

Show what a long-running sync is doing while it runs.

The progress block now shows:

- aggregate activity, GPX, health, and performance totals
- one row for each producer (`P`) fetching from Garmin
- one row for each consumer (`C`) writing locally
- task id, item, current state, and elapsed time

Example:

```text
Act 120/1223 | GPX 80/993 | Health 400/4228 | Perf 90/604 | elapsed 2m 41s
P0  Activities #4855  200-250                  fetching           3s
P1  Health     #4236  2015-01-12               rate limit wait     8s
C0  GPX        #4839  2026-03-17 Run           writing             1s
```

## Scope

This is intentionally limited to the UI for issue #17. It does not change queue claiming, retry semantics, stale-claim ownership, logging, timeout policy, or resume behavior from #18.

Closes #17.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p garmin-cli`
- `cargo clippy -p garmin-cli --all-targets --all-features -- -D warnings`
